### PR TITLE
Keep the `extrahead` contents from the parent template

### DIFF
--- a/django_admin_action_forms/templates/admin/django_admin_action_forms/action_form.html
+++ b/django_admin_action_forms/templates/admin/django_admin_action_forms/action_form.html
@@ -3,6 +3,7 @@
 
 
 {% block extrahead %}
+    {{ block.super }}
     <script src="{% url 'admin:jsi18n' %}"></script>
     <script src="{% static 'admin/js/core.js' %}" ></script>
     <script src="{% static 'admin/js/cancel.js' %}" ></script>


### PR DESCRIPTION
Thanks for this project! Very useful.

I have an admin customization which replaces the nav sidebar with a panel with grouped apps (django-fhadmin); the necessary scripts and styles are added to the `{% block extrahead %}`. The django-admin-action-forms action form template replaces the contents of `extrahead` instead of adding to them, it would be great if that could be changed.

Thanks!