### PR TITLE
Change the german translation of "Cancel"

### DIFF
--- a/django_admin_action_forms/locale/de/LC_MESSAGES/django.po
+++ b/django_admin_action_forms/locale/de/LC_MESSAGES/django.po
@@ -6,4 +6,4 @@ msgid "Confirm"
 msgstr "Bestätigen"
 
 msgid "Cancel"
-msgstr "Stornieren"
+msgstr "Abbrechen"


### PR DESCRIPTION
"Stornieren" is more often used when cancelling invoices, not as a general term for cancelling a process or something.

I think "Abbrechen" is a more commonly used term.

(I was wondering where "Stornieren" came from in the project I was working on!)