### PR TITLE
Add `include_summary` option to ActionForm and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ class ShopProductsTests(TestCase):
 - [`AdminActionForm`](#class-adminactionform)
 - [`ActionForm.Meta`](#class-actionformmeta)
   - [`list_objects`](#list_objects)
+  - [`include_summary`](#include_summary)
   - [`help_text`](#help_text)
   - [`fields`](#fields)
   - [`get_fields()`](#def-get_fieldsrequest)
@@ -519,6 +520,35 @@ to the intermediate page for built-in `delete_selected` action.
 ```python
 class Meta:
     list_objects = True
+```
+
+#### include_summary
+
+Default: `True` if `list_objects` is `True`, otherwise `False`
+
+If `True`, the intermediate page will display a summary section showing the count of objects that will be affected by the action.
+When `list_objects` is `True`, `include_summary` defaults to `True` unless explicitly overridden.
+
+```python
+# Show both summary and individual objects (default behavior when list_objects=True)
+class Meta:
+    list_objects = True
+    # include_summary defaults to True
+
+# Show only individual objects without summary
+class Meta:
+    list_objects = True
+    include_summary = False
+
+# Show only summary without individual objects
+class Meta:
+    list_objects = False
+    include_summary = True
+
+# Show neither summary nor objects
+class Meta:
+    list_objects = False
+    include_summary = False
 ```
 
 #### help_text

--- a/django_admin_action_forms/forms.py
+++ b/django_admin_action_forms/forms.py
@@ -247,6 +247,7 @@ class ActionForm(Form):
             "model_verbose_name_plural": self.modeladmin.opts.verbose_name_plural,
             "help_text": self.opts.help_text,
             "list_objects": self.opts.list_objects,
+            "include_summary": self.opts.include_summary,
             "queryset": self.queryset,
             "form": self,
             "fieldsets": self.fieldsets,
@@ -265,6 +266,7 @@ class ActionForm(Form):
 
         class Meta:
             list_objects: bool
+            include_summary: bool
             help_text: "str | None"
 
             fields: "list[str | tuple[str, ...]] | None"

--- a/django_admin_action_forms/options.py
+++ b/django_admin_action_forms/options.py
@@ -12,6 +12,7 @@ from .formsets import InlineAdminActionFormSet
 class Options:
 
     list_objects: bool
+    include_summary: bool
     help_text: "str | None"
     fields: "list[str | tuple[str, ...]] | None"
     fieldsets: "list[tuple[str|None, dict[str, list[str | tuple[str, ...]]]]] | None"
@@ -28,6 +29,14 @@ class Options:
         self._meta = form.Meta() if hasattr(form, "Meta") else None
 
         self.list_objects = getattr(self._meta, "list_objects", False)
+
+        # If include_summary is explicitly set, use that value
+        # Otherwise, default to True if list_objects is True, False if list_objects is False
+        if hasattr(self._meta, "include_summary"):
+            self.include_summary = self._meta.include_summary
+        else:
+            self.include_summary = self.list_objects
+
         self.help_text = getattr(self._meta, "help_text", None)
         self.fields = getattr(self._meta, "fields", None)
         self.fieldsets = getattr(self._meta, "fieldsets", None)

--- a/django_admin_action_forms/templates/django_admin_action_forms/action_form.html
+++ b/django_admin_action_forms/templates/django_admin_action_forms/action_form.html
@@ -35,14 +35,16 @@
     {% endblock help_text %}
 
     {% block objects_list %}
-        {% if list_objects %}
+        {% if include_summary %}
             <h2>{% translate "Summary" %}</h2>
             <ul>
                 <li>
                     {{ model_verbose_name_plural|capfirst }}: {{ queryset|length }}</a>
                 </li>
             </ul>
-
+        {% endif %}
+    
+        {% if list_objects %}
             <h2>{% translate "Objects" %}</h2>
             <ul>
                 {% for object in queryset %}


### PR DESCRIPTION
- Introduced `include_summary` to control the display of a summary section in the intermediate action form.
- Updated the `README.md` to document the new option and its behavior.
- Modified `forms.py` and `options.py` to support the new option.
- Adjusted the template to conditionally render the summary based on `include_summary`.

This enables adding a quick summary when printing the entire list might be an overkill. At least providing a count of the total records.

It will keep the default behavior, so setting list_objects to true will show the summary. 